### PR TITLE
Expose response errors

### DIFF
--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
@@ -90,7 +90,9 @@ public class ChromeWebSocketClient extends WebSocketClient {
           executorService.submit(() -> eventListener.onEvent(type, event));
         }
       } else if (response.isError()) {
-        LOG.error(response.getError().toString());
+        String errorMessage = response.getError().toString();
+        LOG.error(errorMessage);
+        throw new ChromeDevToolsException(errorMessage, response.getError().getCode());
       }
     } catch (IOException ioe) {
       LOG.error("Could not parse response from chrome", ioe);

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
@@ -25,6 +25,7 @@ import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.hubspot.chrome.devtools.base.ChromeResponse;
+import com.hubspot.chrome.devtools.base.ChromeResponseErrorBody;
 import com.hubspot.chrome.devtools.client.core.Event;
 import com.hubspot.chrome.devtools.client.core.EventType;
 import com.hubspot.chrome.devtools.client.exceptions.ChromeDevToolsException;
@@ -39,6 +40,7 @@ public class ChromeWebSocketClient extends WebSocketClient {
 
   private final Retryer<ChromeResponse> actionRetryer;
 
+  private final Map<Integer, ChromeResponseErrorBody> errorsReceived;
   private final Map<Integer, ChromeResponse> messagesReceived;
   private final ObjectMapper objectMapper;
   private final Map<String, ChromeEventListener> chromeEventListeners;
@@ -53,6 +55,7 @@ public class ChromeWebSocketClient extends WebSocketClient {
     this.objectMapper = objectMapper;
     this.chromeEventListeners = chromeEventListeners;
     this.executorService = executorService;
+    this.errorsReceived = new HashMap<>();
     this.messagesReceived = new HashMap<>();
 
     // The timeout here is merely a safety net in case the user doesn't complete the futures
@@ -90,9 +93,8 @@ public class ChromeWebSocketClient extends WebSocketClient {
           executorService.submit(() -> eventListener.onEvent(type, event));
         }
       } else if (response.isError()) {
-        String errorMessage = response.getError().toString();
-        LOG.error(errorMessage);
-        throw new ChromeDevToolsException(errorMessage, response.getError().getCode());
+        LOG.error(response.getError().toString());
+        errorsReceived.put(response.getId(), response.getError());
       }
     } catch (IOException ioe) {
       LOG.error("Could not parse response from chrome", ioe);
@@ -111,7 +113,13 @@ public class ChromeWebSocketClient extends WebSocketClient {
 
   public ChromeResponse getResponse(int id) {
     try {
-      ChromeResponse response = actionRetryer.call(() -> messagesReceived.get(id));
+      ChromeResponse response = actionRetryer.call(() -> {
+        if (errorsReceived.containsKey(id)) {
+          ChromeResponseErrorBody error = errorsReceived.get(id);
+          throw new ChromeDevToolsException(error.getMessage(), error.getCode());
+        }
+        return messagesReceived.get(id);
+      });
       messagesReceived.remove(id);
       return response;
     } catch (ExecutionException | RetryException e) {

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/exceptions/ChromeDevToolsException.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/exceptions/ChromeDevToolsException.java
@@ -2,16 +2,29 @@ package com.hubspot.chrome.devtools.client.exceptions;
 
 public class ChromeDevToolsException extends RuntimeException {
 
+  private final Integer code;
+
   public ChromeDevToolsException(String message) {
     super(message);
+    this.code = null;
+  }
+
+  public ChromeDevToolsException(String message, Integer code) {
+    super(message);
+    this.code = code;
   }
 
   public ChromeDevToolsException(Throwable cause) {
     super(cause);
+    this.code = null;
   }
 
   public ChromeDevToolsException(String message, Throwable cause) {
     super(message, cause);
+    this.code = null;
   }
 
+  public Integer getCode() {
+    return code;
+  }
 }


### PR DESCRIPTION
We had been just logging out errors like this `ChromeResponseErrorBody{code=-32000, message=Cannot navigate to invalid URL}`. @hs-lsong requested these be exposed so they can handle them accordingly

/cc @ssalinas