### PR TITLE
Fix the build order for the CodeGeneration module

### DIFF
--- a/ChromeDevToolsClient/.blazar.yaml
+++ b/ChromeDevToolsClient/.blazar.yaml
@@ -1,2 +1,2 @@
 depends:
-  - com.hubspot.chrome:CodeGeneration
+  - name: ChromeDevToolsClient-CodeGeneration

--- a/CodeGeneration/.blazar.yaml
+++ b/CodeGeneration/.blazar.yaml
@@ -1,0 +1,2 @@
+provides:
+  - name: ChromeDevToolsClient-CodeGeneration


### PR DESCRIPTION
This PR is to let Blazar know that CodeGeneration should be built before the ChromeDevToolsClient module.