### PR TITLE
Target java 11

### DIFF
--- a/ChromeDevToolsBase/pom.xml
+++ b/ChromeDevToolsBase/pom.xml
@@ -13,17 +13,6 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>1.2</version>
-        <scope>provided</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -40,11 +29,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>

--- a/ChromeDevToolsBase/pom.xml
+++ b/ChromeDevToolsBase/pom.xml
@@ -13,6 +13,17 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.2</version>
+        <scope>compile</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
@@ -33,7 +44,6 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/ChromeDevToolsBase/pom.xml
+++ b/ChromeDevToolsBase/pom.xml
@@ -31,6 +31,12 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>

--- a/ChromeDevToolsBase/pom.xml
+++ b/ChromeDevToolsBase/pom.xml
@@ -19,7 +19,7 @@
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.2</version>
-        <scope>compile</scope>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>

--- a/ChromeDevToolsBase/pom.xml
+++ b/ChromeDevToolsBase/pom.xml
@@ -9,10 +9,6 @@
 
   <artifactId>ChromeDevToolsBase</artifactId>
 
-  <properties>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <project.build.targetJdk>11</project.build.targetJdk>
     <project.build.releaseJdk>${project.build.targetJdk}</project.build.releaseJdk>
     <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
+    <dep.pmd.version>6.21.0</dep.pmd.version>
     <dep.plugin.dependency.version>3.2.0</dep.plugin.dependency.version>
     <dep.plugin.pmd.version>3.13.0</dep.plugin.pmd.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <project.build.releaseJdk>${project.build.targetJdk}</project.build.releaseJdk>
     <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
     <dep.plugin.dependency.version>3.2.0</dep.plugin.dependency.version>
+    <dep.plugin.pmd.version>3.13.0</dep.plugin.pmd.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <v8.version>9.4.146.16</v8.version>
     <project.build.targetJdk>11</project.build.targetJdk>
     <project.build.releaseJdk>${project.build.targetJdk}</project.build.releaseJdk>
+    <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
     <dep.plugin.dependency.version>3.2.0</dep.plugin.dependency.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <v8.version>9.4.146.16</v8.version>
     <project.build.targetJdk>11</project.build.targetJdk>
     <project.build.releaseJdk>${project.build.targetJdk}</project.build.releaseJdk>
+    <dep.plugin.dependency.version>3.2.0</dep.plugin.dependency.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
     <chromium.version>94.0.4606.61</chromium.version>
     <v8.version>9.4.146.16</v8.version>
     <project.build.targetJdk>11</project.build.targetJdk>
-    <project.build.releaseJdk>11</project.build.releaseJdk>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,9 @@
   <properties>
     <chromium.version>94.0.4606.61</chromium.version>
     <v8.version>9.4.146.16</v8.version>
+    <project.build.targetJdk>1.11</project.build.targetJdk>
+    <project.build.sourceJdk>${project.build.targetJdk}</project.build.sourceJdk>
+    <project.build.releaseJdk>11</project.build.releaseJdk>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,7 @@
   <properties>
     <chromium.version>94.0.4606.61</chromium.version>
     <v8.version>9.4.146.16</v8.version>
-    <project.build.targetJdk>1.11</project.build.targetJdk>
-    <project.build.sourceJdk>${project.build.targetJdk}</project.build.sourceJdk>
+    <project.build.targetJdk>11</project.build.targetJdk>
     <project.build.releaseJdk>11</project.build.releaseJdk>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <chromium.version>94.0.4606.61</chromium.version>
     <v8.version>9.4.146.16</v8.version>
     <project.build.targetJdk>11</project.build.targetJdk>
+    <project.build.releaseJdk>${project.build.targetJdk}</project.build.releaseJdk>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
We pull in some deps that seem to target 11, which is likely what's giving us javax.annotation-api issues at release time