### PR TITLE
ignore unknown properties when deserializing ChromeStyle models

### DIFF
--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
@@ -15,6 +15,9 @@ public interface ChromeSessionInfoIF {
   String getUrl();
   String getWebSocketDebuggerUrl();
 
+  /**
+   * Nullable because it's not always present on devtools targets, even in 112+.
+   */
   @Nullable
   String getFaviconUrl();
 }

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
@@ -3,6 +3,8 @@ package com.hubspot.chrome.devtools.base;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.immutables.value.Value.Immutable;
 
+import java.util.Optional;
+
 @Immutable
 @ChromeStyle
 @JsonIgnoreProperties(ignoreUnknown = true) // Ignore unknown properties to handle chrome adding fields to base models
@@ -14,4 +16,6 @@ public interface ChromeSessionInfoIF {
   String getType();
   String getUrl();
   String getWebSocketDebuggerUrl();
+
+  Optional<String> getFaviconUrl();
 }

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
@@ -1,9 +1,11 @@
 package com.hubspot.chrome.devtools.base;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.immutables.value.Value.Immutable;
 
 @Immutable
 @ChromeStyle
+@JsonIgnoreProperties(ignoreUnknown = true) // Ignore unknown properties to handle chrome adding fields to base models
 public interface ChromeSessionInfoIF {
   String getDescription();
   String getDevtoolsFrontendUrl();

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
@@ -1,14 +1,11 @@
 package com.hubspot.chrome.devtools.base;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.immutables.value.Value.Immutable;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 @Immutable
 @ChromeStyle
-@JsonIgnoreProperties(ignoreUnknown = true) // Ignore unknown properties to handle chrome adding fields to base models
 public interface ChromeSessionInfoIF {
   String getDescription();
   String getDevtoolsFrontendUrl();

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
@@ -3,6 +3,7 @@ package com.hubspot.chrome.devtools.base;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.immutables.value.Value.Immutable;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 @Immutable
@@ -17,5 +18,6 @@ public interface ChromeSessionInfoIF {
   String getUrl();
   String getWebSocketDebuggerUrl();
 
-  Optional<String> getFaviconUrl();
+  @Nullable
+  String getFaviconUrl();
 }

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
@@ -20,8 +20,7 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   typeImmutable = "*", // No prefix or suffix for generated immutable type
   optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
   visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-  jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
-  passAnnotations = { JsonIgnoreProperties.class }
+  jdkOnly = true // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
 )
 public @interface ChromeStyle {
 }

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
@@ -1,19 +1,17 @@
 package com.hubspot.chrome.devtools.base;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ImplementationVisibility;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-import org.immutables.value.Value;
-import org.immutables.value.Value.Style.ImplementationVisibility;
-
 @Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation
-@JsonIgnoreProperties(ignoreUnknown = true) // Ignore unknown properties to handle chrome adding fields to base models
 @JsonSerialize
 @Value.Style(
   get = { "is*", "get*" }, // Detect 'get' and 'is' prefixes in accessor methods
@@ -22,7 +20,7 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   typeImmutable = "*", // No prefix or suffix for generated immutable type
   optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
   visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-  jdkOnly = true
-) // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+  jdkOnly = true // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+)
 public @interface ChromeStyle {
 }

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
@@ -3,13 +3,12 @@ package com.hubspot.chrome.devtools.base;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import org.immutables.value.Value;
-import org.immutables.value.Value.Style.ImplementationVisibility;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation
@@ -22,7 +21,7 @@ import java.lang.annotation.Target;
   optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
   visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
   jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
-  passAnnotations = {JsonIgnoreProperties.class}
+  passAnnotations = { JsonIgnoreProperties.class }
 )
 public @interface ChromeStyle {
 }

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
@@ -1,14 +1,13 @@
 package com.hubspot.chrome.devtools.base;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ImplementationVisibility;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.immutables.value.Value;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
@@ -1,5 +1,6 @@
 package com.hubspot.chrome.devtools.base;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import org.immutables.value.Value;
@@ -20,7 +21,8 @@ import java.lang.annotation.Target;
   typeImmutable = "*", // No prefix or suffix for generated immutable type
   optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
   visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-  jdkOnly = true // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+  jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+  passAnnotations = {JsonIgnoreProperties.class}
 )
 public @interface ChromeStyle {
 }

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
@@ -5,11 +5,15 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import org.immutables.value.Value;
 import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation
+@JsonIgnoreProperties(ignoreUnknown = true) // Ignore unknown properties to handle chrome adding fields to base models
 @JsonSerialize
 @Value.Style(
   get = { "is*", "get*" }, // Detect 'get' and 'is' prefixes in accessor methods

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -128,12 +128,10 @@ public class ChromeDevToolsClient implements Closeable {
       throw new ChromeDevToolsException("Unable to find available chrome session info.");
     }
 
-    List<ChromeSessionInfo> sessions = response.getAs(new TypeReference<>() {});
-    if (sessions.size() == 0) {
-      throw new ChromeDevToolsException("Unable to create new websocket target");
-    }
+    TargetID targetID = response.getAs(new TypeReference<>() {});
+    LOG.debug("new TargetID: {}", targetID);
 
-    return new TargetID(sessions.get(0).getId());
+    return targetID;
   }
 
   public static class Builder {

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -128,10 +128,10 @@ public class ChromeDevToolsClient implements Closeable {
       throw new ChromeDevToolsException("Unable to find available chrome session info.");
     }
 
-    TargetID targetID = response.getAs(new TypeReference<>() {});
-    LOG.debug("new TargetID: {}", targetID);
+    ChromeSessionInfo newSession = response.getAs(new TypeReference<>() {});
+    LOG.debug("new session: {}", newSession);
 
-    return targetID;
+    return new TargetID(newSession.getId());
   }
 
   public static class Builder {

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
@@ -22,7 +22,8 @@ public class ChromeDevToolsClientDefaults {
     TimeUnit.SECONDS,
     new LinkedTransferQueue<>()
   );
-  public static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+  public static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper()
+  .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   static {
     DEFAULT_OBJECT_MAPPER.setSerializationInclusion(Include.NON_NULL);
@@ -31,7 +32,9 @@ public class ChromeDevToolsClientDefaults {
     DEFAULT_OBJECT_MAPPER.registerModule(module);
   }
 
-  public static final HttpClient DEFAULT_HTTP_CLIENT = new NingHttpClient(HttpConfig.newBuilder().setObjectMapper(DEFAULT_OBJECT_MAPPER).build());
+  public static final HttpClient DEFAULT_HTTP_CLIENT = new NingHttpClient(
+    HttpConfig.newBuilder().setObjectMapper(DEFAULT_OBJECT_MAPPER).build()
+  );
   public static final int DEFAULT_CHROME_ACTION_TIMEOUT_MILLIS = 60 * 1000;
   public static final int DEFAULT_HTTP_CONNECTION_RETRY_TIMEOUT_MILLIS = 5 * 1000;
   public static final boolean DEFAULT_START_NEW_TARGET = false;

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
@@ -26,6 +26,7 @@ public class ChromeDevToolsClientDefaults {
   .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   static {
+    DEFAULT_OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     DEFAULT_OBJECT_MAPPER.setSerializationInclusion(Include.NON_NULL);
     SimpleModule module = new SimpleModule();
     module.addDeserializer(Event.class, new EventDeserializer());

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.chrome.devtools.client.core.Event;
 import com.hubspot.chrome.devtools.client.core.EventDeserializer;
 import com.hubspot.horizon.HttpClient;
+import com.hubspot.horizon.HttpConfig;
 import com.hubspot.horizon.ning.NingHttpClient;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedTransferQueue;
@@ -30,7 +31,7 @@ public class ChromeDevToolsClientDefaults {
     DEFAULT_OBJECT_MAPPER.registerModule(module);
   }
 
-  public static final HttpClient DEFAULT_HTTP_CLIENT = new NingHttpClient();
+  public static final HttpClient DEFAULT_HTTP_CLIENT = new NingHttpClient(HttpConfig.newBuilder().setObjectMapper(DEFAULT_OBJECT_MAPPER).build());
   public static final int DEFAULT_CHROME_ACTION_TIMEOUT_MILLIS = 60 * 1000;
   public static final int DEFAULT_HTTP_CONNECTION_RETRY_TIMEOUT_MILLIS = 5 * 1000;
   public static final boolean DEFAULT_START_NEW_TARGET = false;

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
@@ -21,13 +21,9 @@ public class ChromeDevToolsClientDefaults {
     TimeUnit.SECONDS,
     new LinkedTransferQueue<>()
   );
-  public static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper();
+  public static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   static {
-    DEFAULT_OBJECT_MAPPER.configure(
-      DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-      false
-    );
     DEFAULT_OBJECT_MAPPER.setSerializationInclusion(Include.NON_NULL);
     SimpleModule module = new SimpleModule();
     module.addDeserializer(Event.class, new EventDeserializer());


### PR DESCRIPTION
This PR addresses broken deserialization due to a new faviconUrl field in ChromeSessionInfo discovered when testing against chromium 110.

Tried to just use @JsonIgnoreProperties, but could not get that annotation passed through to the JSON immutable class.

Tried to modify the default object mapper, including making it used by the default http client, but that still had deserialization issues.

Tried making faviconUrl a new optional field, but the default jackson deserialization doesn't support that.

Gave up and made faviconUrl a nullable field, which should also be backwards compatible.

Also ran prettier, because I noticed it wasn't getting run by default.

cc @ssalinas @pschoenfelder 