### PR TITLE
Add sessionId to ChromeResponse

### DIFF
--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeResponseIF.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeResponseIF.java
@@ -20,6 +20,9 @@ public interface ChromeResponseIF {
   JsonNode getParams();
 
   @Nullable
+  String getSessionId();
+
+  @Nullable
   ChromeResponseErrorBody getError();
 
   default boolean isResponse() {

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeEventListener.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeEventListener.java
@@ -2,7 +2,13 @@ package com.hubspot.chrome.devtools.client;
 
 import com.hubspot.chrome.devtools.client.core.Event;
 import com.hubspot.chrome.devtools.client.core.EventType;
+import com.hubspot.chrome.devtools.client.core.target.SessionID;
+import javax.annotation.Nullable;
 
 public interface ChromeEventListener {
   void onEvent(EventType type, Event event);
+
+  default void onEvent(@Nullable SessionID sessionId, EventType type, Event event) {
+    onEvent(type, event);
+  }
 }

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
@@ -10,6 +10,7 @@ import com.hubspot.chrome.devtools.base.ChromeResponse;
 import com.hubspot.chrome.devtools.base.ChromeResponseErrorBody;
 import com.hubspot.chrome.devtools.client.core.Event;
 import com.hubspot.chrome.devtools.client.core.EventType;
+import com.hubspot.chrome.devtools.client.core.target.SessionID;
 import com.hubspot.chrome.devtools.client.exceptions.ChromeDevToolsException;
 import java.io.IOException;
 import java.net.URI;
@@ -97,9 +98,10 @@ public class ChromeWebSocketClient extends WebSocketClient {
         messagesReceived.put(response.getId(), response);
       } else if (response.isEvent()) {
         Event event = objectMapper.readValue(message, Event.class);
+        SessionID sessionId = response.getSessionId() == null ? null : new SessionID(response.getSessionId());
         for (ChromeEventListener eventListener : chromeEventListeners.values()) {
           EventType type = EVENT_TYPES.get(response.getMethod());
-          executorService.submit(() -> eventListener.onEvent(type, event));
+          executorService.submit(() -> eventListener.onEvent(sessionId, type, event));
         }
       } else if (response.isError()) {
         LOG.error(response.getError().toString());

--- a/ChromeDevToolsClient/src/test/java/com/hubspot/chrome/devtools/client/EventListenerTest.java
+++ b/ChromeDevToolsClient/src/test/java/com/hubspot/chrome/devtools/client/EventListenerTest.java
@@ -4,14 +4,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.chrome.devtools.client.core.EventType;
+import com.hubspot.chrome.devtools.client.core.page.DomContentEventFiredEvent;
+import com.hubspot.chrome.devtools.client.core.page.LoadEventFiredEvent;
 import com.hubspot.chrome.devtools.client.core.runtime.ConsoleAPICalledEvent;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class EventListenerTest {
@@ -121,5 +125,58 @@ public class EventListenerTest {
     ConsoleAPICalledEvent consoleAPICalledEvent = events.get(0);
     assertThat(consoleAPICalledEvent.getType()).isEqualTo("myType");
     assertThat(consoleAPICalledEvent.getContext()).isEqualTo("myContext");
+  }
+
+  @Test
+  public void itAddsFlatModeCustomConsumers() throws Exception {
+    ObjectMapper objectMapper = ChromeDevToolsClientDefaults.DEFAULT_OBJECT_MAPPER;
+    ExecutorService executorService =
+      ChromeDevToolsClientDefaults.DEFAULT_EXECUTOR_SERVICE;
+    Map<String, ChromeEventListener> listeners = new ConcurrentHashMap<>();
+
+    ChromeWebSocketClient client = new ChromeWebSocketClient(
+      URI.create(""),
+      objectMapper,
+      listeners,
+      executorService,
+      1000L
+    );
+
+    ChromeDevToolsSession chromeDevToolsSession = new ChromeDevToolsSession(
+      listeners,
+      client,
+      objectMapper,
+      executorService
+    );
+
+    EventType eventType = EventType.PAGE_LOAD_EVENT_FIRED;
+    Map<String, LoadEventFiredEvent> events = new HashMap<>();
+    chromeDevToolsSession.addEventConsumer(
+      eventType,
+      (sessionId, event) -> events.put(sessionId == null ? "None" : sessionId.getValue(), (LoadEventFiredEvent) event)
+    );
+
+    String jsonWithoutSessionId =
+      "{\"method\":\"" +
+      eventType.getType() +
+      "\",\"params\":" +
+      "{\"timestamp\":1.0}" +
+      "}";
+    String jsonWithSessionId =
+      "{\"method\":\"" +
+      eventType.getType() +
+      "\",\"sessionId\":\"" +
+      "test-session-id" +
+      "\",\"params\":" +
+      "{\"timestamp\":2.0}" +
+      "}";
+
+    client.onMessage(jsonWithoutSessionId);
+    client.onMessage(jsonWithSessionId);
+    Thread.sleep(10); // debounce for the executor service handling messages
+
+    assertThat(events.size()).isEqualTo(2);
+    assertThat(events.get("None").getTimestamp().getValue().intValue()).isEqualTo(1);
+    assertThat(events.get("test-session-id").getTimestamp().getValue().intValue()).isEqualTo(2);
   }
 }


### PR DESCRIPTION
Adds SessionId field support to ChromeResponse and allows it to be optionally used by ChromeEventListeners which specify three parameters. This allows users of "flat" mode (see: https://chromedevtools.github.io/devtools-protocol/tot/Target/#type-TargetID) to differentiate events based on the origin target.