### PR TITLE
upgrade basepom, apply prettier formatting

### DIFF
--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeRequest.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeRequest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ChromeRequest {
+
   // It's *much* easier to implement this as a POJO instead of an immutable for two reasons:
   //
   //  1. Immutable::putParams does not allow setting null values (even with

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeSessionInfoIF.java
@@ -1,8 +1,7 @@
 package com.hubspot.chrome.devtools.base;
 
-import org.immutables.value.Value.Immutable;
-
 import javax.annotation.Nullable;
+import org.immutables.value.Value.Immutable;
 
 @Immutable
 @ChromeStyle

--- a/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
+++ b/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeStyle.java
@@ -1,13 +1,12 @@
 package com.hubspot.chrome.devtools.base;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value;
-import org.immutables.value.Value.Style.ImplementationVisibility;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ChromeDevToolsClient implements Closeable {
+
   private static final Logger LOG = LoggerFactory.getLogger(ChromeDevToolsClient.class);
 
   private static final String WEBSOCKET_URL_TEMPLATE = "ws://%s:%s/devtools/page/%s";
@@ -135,6 +136,7 @@ public class ChromeDevToolsClient implements Closeable {
   }
 
   public static class Builder {
+
     private ExecutorService executorService;
     private ObjectMapper objectMapper;
     private HttpClient httpClient;

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClientDefaults.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class ChromeDevToolsClientDefaults {
+
   public static final ExecutorService DEFAULT_EXECUTOR_SERVICE = new ThreadPoolExecutor(
     10,
     10,
@@ -23,10 +24,13 @@ public class ChromeDevToolsClientDefaults {
     new LinkedTransferQueue<>()
   );
   public static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper()
-  .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   static {
-    DEFAULT_OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    DEFAULT_OBJECT_MAPPER.configure(
+      DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+      false
+    );
     DEFAULT_OBJECT_MAPPER.setSerializationInclusion(Include.NON_NULL);
     SimpleModule module = new SimpleModule();
     module.addDeserializer(Event.class, new EventDeserializer());

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
@@ -87,6 +87,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ChromeDevToolsSession implements ChromeSessionCore {
+
   private final Logger LOG = LoggerFactory.getLogger(ChromeDevToolsSession.class);
 
   public static final long DEFAULT_TIMEOUT_MILLIS = 10000L;
@@ -254,8 +255,8 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
       .withWaitStrategy(WaitStrategies.fixedWait(periodMillis, TimeUnit.MILLISECONDS))
       .build();
     try {
-      retryer.call(
-        () -> (Boolean) evaluate("document.readyState === \"complete\"").result.getValue()
+      retryer.call(() ->
+        (Boolean) evaluate("document.readyState === \"complete\"").result.getValue()
       );
     } catch (ExecutionException | RetryException e) {
       throw new ChromeDevToolsException(e);
@@ -410,7 +411,10 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     return listenerId;
   }
 
-  public <T> String addEventConsumer(EventType eventType, BiConsumer<SessionID, T> eventConsumer) {
+  public <T> String addEventConsumer(
+    EventType eventType,
+    BiConsumer<SessionID, T> eventConsumer
+  ) {
     String listenerId = String.format(
       "ChromeDevToolsSession-%s-%sConsumer-%s",
       id,

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/FileExtension.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/FileExtension.java
@@ -2,5 +2,5 @@ package com.hubspot.chrome.devtools.client;
 
 public enum FileExtension {
   PDF,
-  PNG
+  PNG,
 }

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/examples/ScreenshotExample.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/examples/ScreenshotExample.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 // Run chrome with args --headless --disable-gpu --remote-debugging-port=9292
 public class ScreenshotExample {
+
   private static String url = "https://www.google.com/";
   private static String cssSelector = "#searchform.jhp";
 

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/exceptions/ChromeDevToolsException.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/exceptions/ChromeDevToolsException.java
@@ -1,6 +1,7 @@
 package com.hubspot.chrome.devtools.client.exceptions;
 
 public class ChromeDevToolsException extends RuntimeException {
+
   private final Integer code;
 
   public ChromeDevToolsException(String message) {

--- a/ChromeDevToolsClient/src/test/java/com/hubspot/chrome/devtools/client/EventListenerTest.java
+++ b/ChromeDevToolsClient/src/test/java/com/hubspot/chrome/devtools/client/EventListenerTest.java
@@ -153,7 +153,11 @@ public class EventListenerTest {
     Map<String, LoadEventFiredEvent> events = new HashMap<>();
     chromeDevToolsSession.addEventConsumer(
       eventType,
-      (sessionId, event) -> events.put(sessionId == null ? "None" : sessionId.getValue(), (LoadEventFiredEvent) event)
+      (sessionId, event) ->
+        events.put(
+          sessionId == null ? "None" : sessionId.getValue(),
+          (LoadEventFiredEvent) event
+        )
     );
 
     String jsonWithoutSessionId =
@@ -177,6 +181,7 @@ public class EventListenerTest {
 
     assertThat(events.size()).isEqualTo(2);
     assertThat(events.get("None").getTimestamp().getValue().intValue()).isEqualTo(1);
-    assertThat(events.get("test-session-id").getTimestamp().getValue().intValue()).isEqualTo(2);
+    assertThat(events.get("test-session-id").getTimestamp().getValue().intValue())
+      .isEqualTo(2);
   }
 }

--- a/ChromeDevToolsClient/src/test/java/com/hubspot/chrome/devtools/client/SerializationTest.java
+++ b/ChromeDevToolsClient/src/test/java/com/hubspot/chrome/devtools/client/SerializationTest.java
@@ -136,6 +136,7 @@ public class SerializationTest {
   }
 
   static class SpyListener implements ChromeEventListener {
+
     private OnEventInvocation lastOnEventCallParams;
 
     @Override
@@ -154,6 +155,7 @@ public class SerializationTest {
   }
 
   private static class OnEventInvocation {
+
     private final SessionID sessionId;
     private final Event event;
     private final EventType type;

--- a/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/ClassPackageResolver.java
+++ b/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/ClassPackageResolver.java
@@ -1,6 +1,7 @@
 package com.hubspot.chrome.devtools.codegen;
 
 public class ClassPackageResolver {
+
   private String packageName;
   private String className;
 

--- a/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
+++ b/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.lang.model.element.Modifier;
 
 public class Generator {
+
   private static final String GENERATED_CODE_PACKAGE_NAME =
     "com.hubspot.chrome.devtools.client.core";
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.7</version>
+    <version>59.2</version>
   </parent>
   <groupId>com.hubspot.chrome</groupId>
   <artifactId>ChromeDevTools-parent</artifactId>
@@ -20,9 +20,7 @@
   <properties>
     <chromium.version>120.0.6099.109</chromium.version>
     <v8.version>12.0.267.10</v8.version>
-    <project.build.targetJdk>11</project.build.targetJdk>
-    <project.build.releaseJdk>${project.build.targetJdk}</project.build.releaseJdk>
-    <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
+    <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR upgrades basepom version to 59, which includes some prettier formatting changes and dependency upgrades.

Basepom 59.2 changes target JDK from 8 to 11, but this build was already targeting 11 so no releases need be made prior.
