### PR TITLE
Don't continue retrying if websocket is closed

### DIFF
--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
@@ -135,6 +135,9 @@ public class ChromeWebSocketClient extends WebSocketClient {
           ChromeResponseErrorBody error = errorsReceived.get(id);
           throw new ChromeDevToolsException(error.getMessage(), error.getCode());
         }
+        if (!isOpen()) {
+          throw new ChromeDevToolsException("Websocket is not connected");
+        }
         return messagesReceived.get(id);
       });
       messagesReceived.remove(id);


### PR DESCRIPTION
Short circuits the retryer if the websocket is closed to prevent needlessly waiting.