### PR TITLE
Customize object mapper in code generator

### DIFF
--- a/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
+++ b/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
@@ -230,6 +230,22 @@ public class Generator {
     for (Entry<Domain, List<TypeSpec>> entry : pojos.entrySet()) {
       Domain domain = entry.getKey();
       for (TypeSpec typeSpec : entry.getValue()) {
+        if(typeSpec.name.contains("responseReceivedExtraInfo")) {
+          deserializationBuilder
+              .addCode(
+                  "case $S: ",
+                  domain.getName() +
+                      "." +
+                      uncapitalize(replaceAtEnd(typeSpec.name, "Event", ""))
+              )
+              .addCode("{\n$>")
+              .addCode("((ObjectNode) p).remove(\"cookiePartitionKey\")")
+              .addStatement(
+                  "return objectMapper.readValue(node.findValue(\"params\").toString(), $T.class)",
+                  getTypeName(typeSpec.name, getPackageName(domain))
+              )
+              .addCode("$<}\n");
+        } else {
         deserializationBuilder
           .addCode(
             "case $S: ",
@@ -243,6 +259,7 @@ public class Generator {
             getTypeName(typeSpec.name, getPackageName(domain))
           )
           .addCode("$<}\n");
+        }
       }
     }
 

--- a/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
+++ b/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
@@ -230,35 +230,35 @@ public class Generator {
     for (Entry<Domain, List<TypeSpec>> entry : pojos.entrySet()) {
       Domain domain = entry.getKey();
       for (TypeSpec typeSpec : entry.getValue()) {
-        if(typeSpec.name.contains("responseReceivedExtraInfo")) {
+        if (typeSpec.name.contains("responseReceivedExtraInfo")) {
           deserializationBuilder
-              .addCode(
-                  "case $S: ",
-                  domain.getName() +
-                      "." +
-                      uncapitalize(replaceAtEnd(typeSpec.name, "Event", ""))
-              )
-              .addCode("{\n$>")
-              .addCode("((ObjectNode) p).remove(\"cookiePartitionKey\")")
-              .addStatement(
-                  "return objectMapper.readValue(node.findValue(\"params\").toString(), $T.class)",
-                  getTypeName(typeSpec.name, getPackageName(domain))
-              )
-              .addCode("$<}\n");
+            .addCode(
+              "case $S: ",
+              domain.getName() +
+              "." +
+              uncapitalize(replaceAtEnd(typeSpec.name, "Event", ""))
+            )
+            .addCode("{\n$>")
+            .addCode("((ObjectNode) p).remove(\"cookiePartitionKey\")")
+            .addStatement(
+              "return objectMapper.readValue(node.findValue(\"params\").toString(), $T.class)",
+              getTypeName(typeSpec.name, getPackageName(domain))
+            )
+            .addCode("$<}\n");
         } else {
-        deserializationBuilder
-          .addCode(
-            "case $S: ",
-            domain.getName() +
-            "." +
-            uncapitalize(replaceAtEnd(typeSpec.name, "Event", ""))
-          )
-          .addCode("{\n$>")
-          .addStatement(
-            "return objectMapper.readValue(node.findValue(\"params\").toString(), $T.class)",
-            getTypeName(typeSpec.name, getPackageName(domain))
-          )
-          .addCode("$<}\n");
+          deserializationBuilder
+            .addCode(
+              "case $S: ",
+              domain.getName() +
+              "." +
+              uncapitalize(replaceAtEnd(typeSpec.name, "Event", ""))
+            )
+            .addCode("{\n$>")
+            .addStatement(
+              "return objectMapper.readValue(node.findValue(\"params\").toString(), $T.class)",
+              getTypeName(typeSpec.name, getPackageName(domain))
+            )
+            .addCode("$<}\n");
         }
       }
     }

--- a/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
+++ b/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
@@ -205,7 +205,8 @@ public class Generator {
             DeserializationFeature.class,
             "FAIL_ON_UNKNOWN_PROPERTIES"
           )
-          .addStatement("this.objectMapper.configure($T.$N, false);",
+          .addStatement(
+            "this.objectMapper.configure($T.$N, false);",
             DeserializationFeature.class,
             "FAIL_ON_INVALID_SUBTYPE"
           )

--- a/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
+++ b/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
@@ -239,7 +239,7 @@ public class Generator {
               uncapitalize(replaceAtEnd(typeSpec.name, "Event", ""))
             )
             .addCode("{\n$>")
-            .addCode("((ObjectNode) p).remove(\"cookiePartitionKey\")")
+            .addStatement("((ObjectNode) p).remove(\"cookiePartitionKey\")")
             .addStatement(
               "return objectMapper.readValue(node.findValue(\"params\").toString(), $T.class)",
               getTypeName(typeSpec.name, getPackageName(domain))

--- a/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
+++ b/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
@@ -205,6 +205,10 @@ public class Generator {
             DeserializationFeature.class,
             "FAIL_ON_UNKNOWN_PROPERTIES"
           )
+          .addStatement("this.objectMapper.configure($T.$N, false);",
+            DeserializationFeature.class,
+            "FAIL_ON_INVALID_SUBTYPE"
+          )
           .build()
       );
 


### PR DESCRIPTION
This PR changes the code that generates the object mapper used to parse different types of Chrome events