### PR TITLE
Update ChromeWebSocketClient.java

### DIFF
--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeWebSocketClient.java
@@ -111,7 +111,7 @@ public class ChromeWebSocketClient extends WebSocketClient {
         errorsReceived.put(response.getId(), response.getError());
       }
     } catch (IOException ioe) {
-      LOG.error("Could not parse response from chrome", ioe);
+      LOG.warn("Could not parse response from chrome. Ignoring this response.", ioe);
     }
   }
 


### PR DESCRIPTION
Lower the log level for a message related to a caught and swallowed chrome exception from error to warn.