### PR TITLE
parseChromeResponse results flattening flawed? #85

### DIFF
--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
@@ -189,42 +189,10 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   }
 
   private <T> T parseChromeResponse(ChromeResponse response, TypeReference<T> valueType) {
-    // Most methods return a single element of data. To eliminate the user needing to access this
-    // single element via a pass through method, we skip the root node and map the element's data right
-    // into the data structure we want (i.e. we don't parse the root node itself).
-    //
-    //   e.g. { "result" : { "browserContextId" : "some_id" } }
-    //                               ^--- ignore      ^--- consume directly so user can act directly on string
-    //
-    //       Allows the user to do `callingMethod()` instead of `callingMethod().getBrowserContextId()`.
-    //
-    // If this fails, then the method is one of the few cases where there are multiple
-    // results that need to be mapped into a parent data structure.
-    //
-    //   e.g. { "result" : { "protocolVersion" : "1.2.3" }, { "jsVersion" : "6.6.8" } }
-    //                    |__________________________________________________________|
-    //                                       `--------- must consume all so user can select which element to work with
-    //
-    //       Here the user must do `callingMethod().getProtocolVersion()` or `someMethod().getJsVersion()`.
-    Iterator<JsonNode> elements = response.getResult().elements();
-    JsonNode first = elements.next();
     try {
-      // We do our best to predict which kind of result to consume the response as, but there's
-      // a small chance that a multi-result response has optional, absent members, and we try and
-      // fail to parse it as a single-result response, which is why we catch the inner JsonMappingException.
-      if (elements.hasNext()) {
-        return objectMapper.readValue(response.getResult().toString(), valueType);
-      } else {
-        return objectMapper.readValue(objectMapper.treeAsTokens(first), valueType);
-      }
-    } catch (JsonMappingException e) {
-      try {
-        return objectMapper.readValue(response.getResult().toString(), valueType);
-      } catch (IOException e1) {
-        throw new ChromeDevToolsException(e1);
-      }
-    } catch (IOException e2) {
-      throw new ChromeDevToolsException(e2);
+      return objectMapper.readValue(response.getResult().toString(), valueType);
+    } catch (IOException | NullPointerException e) {
+      throw new ChromeDevToolsException(e);
     }
   }
 
@@ -298,7 +266,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   }
 
   public String getUrl() {
-    return getDOM().getDocument(null, null).getDocumentURL();
+    return getDOM().getDocument(null, null).root.getDocumentURL();
   }
 
   public EvaluateResult evaluate(String javascript) {
@@ -323,11 +291,13 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   }
 
   public FrameId getFrameId() {
-    return getDOM().getDocument(null, null).getFrameId();
+    return getDOM().getDocument(null, null).root.getFrameId();
   }
 
   public List<NodeId> getNodeIds(String selector) {
-    return getDOM().querySelectorAll(getDOM().getDocument(1, null).getNodeId(), selector);
+    return getDOM()
+      .querySelectorAll(getDOM().getDocument(1, null).root.getNodeId(), selector)
+      .nodeIds;
   }
 
   public NodeId getNodeId(String selector) {
@@ -341,7 +311,8 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
 
   public byte[] captureScreenshot(FileExtension extension) {
     String data = getPage()
-      .captureScreenshot(extension.name().toLowerCase(), null, null, null, null);
+      .captureScreenshot(extension.name().toLowerCase(), null, null, null, null)
+      .data;
     return Base64.getDecoder().decode(data);
   }
 
@@ -537,15 +508,15 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
 
   public RemoteObjectId getObjectId(String selector) {
     DOM dom = getDOM();
-    NodeId root = dom.getDocument(null, null).getNodeId();
+    NodeId root = dom.getDocument(null, null).root.getNodeId();
     if (root == null) {
       return null;
     }
-    NodeId selectedNodeId = dom.querySelector(root, selector);
+    NodeId selectedNodeId = dom.querySelector(root, selector).nodeId;
     if (selectedNodeId == null) {
       return null;
     }
-    RemoteObject remoteObject = dom.resolveNode(selectedNodeId, null, null, null);
+    RemoteObject remoteObject = dom.resolveNode(selectedNodeId, null, null, null).object;
     if (remoteObject == null) {
       return null;
     }
@@ -553,7 +524,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   }
 
   public String getLocation() {
-    return getDOM().getDocument(null, null).getDocumentURL();
+    return getDOM().getDocument(null, null).root.getDocumentURL();
   }
 
   public boolean click(String selector) {
@@ -561,7 +532,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     if (selectedNodeId == null) {
       return false;
     }
-    BoxModel boxModel = getDOM().getBoxModel(selectedNodeId, null, null);
+    BoxModel boxModel = getDOM().getBoxModel(selectedNodeId, null, null).model;
     if (boxModel == null) {
       return false;
     }

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/examples/ScreenshotExample.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/examples/ScreenshotExample.java
@@ -38,7 +38,8 @@ public class ScreenshotExample {
       // Locate the element on the page
       BoxModel boxModel = session
         .getDOM()
-        .getBoxModel(session.getNodeId(cssSelector), null, null);
+        .getBoxModel(session.getNodeId(cssSelector), null, null)
+        .model;
       int width = boxModel.getWidth();
       int height = boxModel.getHeight(); // includes shadows
 
@@ -58,7 +59,8 @@ public class ScreenshotExample {
       // Get the screenshot data as a base 64 encoded string
       String base64Data = session
         .getPage()
-        .captureScreenshot("png", null, clip, null, null);
+        .captureScreenshot("png", null, clip, null, null)
+        .data;
       byte[] data = Base64.getDecoder().decode(base64Data);
 
       // Alternatively use the client shortcut to capture either a PNG or PDF screenshot

--- a/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
+++ b/CodeGeneration/src/main/java/com/hubspot/chrome/devtools/codegen/Generator.java
@@ -661,10 +661,7 @@ public class Generator {
     // Sometimes chrome will return multiple objects. This creates classes that will
     // encapsulate those types into a single class.
     List<Property> returnValues = command.getReturns().orElse(Collections.emptyList());
-    if (returnValues.size() > 1) {
-      return Optional.of(buildContainerForMultipleReturns(command, domain, returnValues));
-    }
-    return Optional.empty();
+    return Optional.of(buildContainerForMultipleReturns(command, domain, returnValues));
   }
 
   private TypeSpec buildContainerForMultipleReturns(
@@ -777,12 +774,11 @@ public class Generator {
         packageName,
         returnTypeName.get()
       );
-      TypeName valueType = returnValues.size() == 1
-        ? getTypeName(returnValues.get(0), packageName)
-        : ClassName.get(
-          classPackageResolver.getPackageName(),
-          classPackageResolver.getClassName()
-        );
+
+      TypeName valueType = ClassName.get(
+        classPackageResolver.getPackageName(),
+        classPackageResolver.getClassName()
+      );
 
       TypeName returnType = valueType;
       if (async) {


### PR DESCRIPTION
- Remove flattening of return types

This fix may be contentious as it changes the existing interface.

I have wondered about different ways of doing this, but the flattening method of removing intermediate response objects (whilst seeming to make sense for trivial stuff) does not hold up in a generic way for more complex returns; especially with multiple optional objects. I also find that it obscures the interface in the documentation.

To that end I have removed the flattening behaviour. So this means that statements like the following: 

```
BrowserContextID browserContextId = getTarget().createBrowserContext();
```
Now need to add the object tree traversal:

```
BrowserContextID browserContextId = getTarget().createBrowserContext().browserContextId;
```
