### PR TITLE
Fix missing class def issues in base module

### DIFF
--- a/ChromeDevToolsBase/pom.xml
+++ b/ChromeDevToolsBase/pom.xml
@@ -35,4 +35,46 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.immutables</groupId>
+              <artifactId>value</artifactId>
+              <version>${dep.immutables.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Aimmutables.gradle.incremental</arg>
+          </compilerArgs>
+          <useIncrementalCompilation>false</useIncrementalCompilation>
+          <proc>only</proc>
+        </configuration>
+        <executions>
+          <execution>
+            <id>process-annotations</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+          <execution>
+            <id>default-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <proc>none</proc>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/CodeGeneration/pom.xml
+++ b/CodeGeneration/pom.xml
@@ -76,4 +76,46 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.immutables</groupId>
+              <artifactId>value</artifactId>
+              <version>${dep.immutables.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Aimmutables.gradle.incremental</arg>
+          </compilerArgs>
+          <useIncrementalCompilation>false</useIncrementalCompilation>
+          <proc>only</proc>
+        </configuration>
+        <executions>
+          <execution>
+            <id>process-annotations</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+          <execution>
+            <id>default-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <proc>none</proc>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Fix base module build failures caused by: 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project ChromeDevToolsBase: Compilation failure
[ERROR] /usr/share/hubspot/build/workspace/ChromeDevToolsClient/ChromeDevToolsBase/src/main/java/com/hubspot/chrome/devtools/base/ChromeResponseIF.java:[26,3] cannot find symbol
[ERROR]   symbol:   class ChromeResponseErrorBody
[ERROR]   location: interface com.hubspot.chrome.devtools.base.ChromeResponseIF
```