### PR TITLE
Add connect(host, port, targetId) and getTargetId() for stateless session reconnection

### DIFF
--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -82,6 +82,20 @@ public class ChromeDevToolsClient implements Closeable {
     );
   }
 
+  public ChromeDevToolsSession connect(String host, int port, String targetId) {
+    String uri = String.format(WEBSOCKET_URL_TEMPLATE, host, port, targetId);
+    try {
+      return new ChromeDevToolsSession(
+        new URI(uri),
+        objectMapper,
+        executorService,
+        actionTimeoutMillis
+      );
+    } catch (URISyntaxException e) {
+      throw new ChromeDevToolsException(e);
+    }
+  }
+
   @Override
   public void close() {
     try {

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -82,18 +82,14 @@ public class ChromeDevToolsClient implements Closeable {
     );
   }
 
-  public ChromeDevToolsSession connect(String host, int port, String targetId) {
+  public ChromeDevToolsSession connect(String host, int port, String targetId) throws URISyntaxException {
     String uri = String.format(WEBSOCKET_URL_TEMPLATE, host, port, targetId);
-    try {
-      return new ChromeDevToolsSession(
-        new URI(uri),
-        objectMapper,
-        executorService,
-        actionTimeoutMillis
-      );
-    } catch (URISyntaxException e) {
-      throw new ChromeDevToolsException(e);
-    }
+    return new ChromeDevToolsSession(
+      new URI(uri),
+      objectMapper,
+      executorService,
+      actionTimeoutMillis
+    );
   }
 
   @Override

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
@@ -96,6 +96,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   private final ObjectMapper objectMapper;
   private final ExecutorService executorService;
   private final UUID id;
+  private final String targetId;
 
   private final Map<String, ChromeEventListener> chromeEventListeners;
 
@@ -117,6 +118,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     this.objectMapper = objectMapper;
     this.executorService = executorService;
     this.id = UUID.randomUUID();
+    this.targetId = uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
 
     try {
       this.websocket.connectBlocking();
@@ -139,6 +141,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     this.objectMapper = objectMapper;
     this.executorService = executorService;
     this.id = UUID.randomUUID();
+    this.targetId = null;
   }
 
   @Override
@@ -236,6 +239,10 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
 
   public boolean isConnected() {
     return websocket.isOpen();
+  }
+
+  public String getTargetId() {
+    return targetId;
   }
 
   public void waitDocumentReady() {


### PR DESCRIPTION
https://github.com/HubSpotEngineering/fintech-sox-tooling-issues/issues/130

## Summary
- Adds a `connect(host, port, targetId)` overload to `ChromeDevToolsClient` to allow reconnecting to an existing session without needing to re-discover the target
- Adds `getTargetId()` to `ChromeDevToolsSession` to expose the target ID for use in stateless reconnection scenarios

## Why
Enables stateless browser session reconnection where the caller already knows the target ID (e.g. stored from a previous session) and needs to reconnect directly without re-fetching the target list.