### PR TITLE
Add connect(host, port, targetId) and getTargetId() for stateless session reconnection

### DIFF
--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -67,29 +67,34 @@ public class ChromeDevToolsClient implements Closeable {
     return new Builder().build();
   }
 
-  public ChromeDevToolsSession connect(String host, int port) {
+  public ChromeDevToolsSession connect(String host, int port) throws URISyntaxException {
     TargetID targetId;
     try {
       targetId = httpRetryer.call(() -> getFirstAvailableTargetId(host, port));
     } catch (ExecutionException | RetryException e) {
       throw new ChromeDevToolsException(e);
     }
-    return connect(host, port, targetId);
+    return connectToTarget(host, port, targetId);
   }
 
   public ChromeDevToolsSession connect(String host, int port, TargetID targetId) {
-    String uri = String.format(WEBSOCKET_URL_TEMPLATE, host, port, targetId);
     try {
-      return new ChromeDevToolsSession(
-        new URI(uri),
-        Optional.of(targetId),
-        objectMapper,
-        executorService,
-        actionTimeoutMillis
-      );
+      return connectToTarget(host, port, targetId);
     } catch (URISyntaxException e) {
       throw new ChromeDevToolsException(e);
     }
+  }
+
+  private ChromeDevToolsSession connectToTarget(String host, int port, TargetID targetId)
+    throws URISyntaxException {
+    String uri = String.format(WEBSOCKET_URL_TEMPLATE, host, port, targetId);
+    return new ChromeDevToolsSession(
+      new URI(uri),
+      Optional.of(targetId),
+      objectMapper,
+      executorService,
+      actionTimeoutMillis
+    );
   }
 
   @Override

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -66,23 +66,17 @@ public class ChromeDevToolsClient implements Closeable {
     return new Builder().build();
   }
 
-  public ChromeDevToolsSession connect(String host, int port) throws URISyntaxException {
+  public ChromeDevToolsSession connect(String host, int port) {
     TargetID targetId;
     try {
       targetId = httpRetryer.call(() -> getFirstAvailableTargetId(host, port));
     } catch (ExecutionException | RetryException e) {
       throw new ChromeDevToolsException(e);
     }
-    String uri = String.format(WEBSOCKET_URL_TEMPLATE, host, port, targetId);
-    return new ChromeDevToolsSession(
-      new URI(uri),
-      objectMapper,
-      executorService,
-      actionTimeoutMillis
-    );
+    return connect(host, port, targetId);
   }
 
-  public ChromeDevToolsSession connect(String host, int port, String targetId) {
+  public ChromeDevToolsSession connect(String host, int port, TargetID targetId) {
     String uri = String.format(WEBSOCKET_URL_TEMPLATE, host, port, targetId);
     try {
       return new ChromeDevToolsSession(

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -82,6 +82,20 @@ public class ChromeDevToolsClient implements Closeable {
     );
   }
 
+  public ChromeDevToolsSession connect(String host, int port, String targetId) {
+    String uri = String.format(WEBSOCKET_URL_TEMPLATE, host, port, targetId);
+    try {
+      return new ChromeDevToolsSession(
+        new URI(uri),
+        objectMapper,
+        executorService,
+        actionTimeoutMillis
+      );
+    } catch (URISyntaxException e) {
+      throw new ChromeDevToolsException(e);
+    }
+  }
+
   @Override
   public void close() {
     try {

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -81,6 +81,7 @@ public class ChromeDevToolsClient implements Closeable {
     try {
       return new ChromeDevToolsSession(
         new URI(uri),
+        targetId,
         objectMapper,
         executorService,
         actionTimeoutMillis

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -19,6 +19,7 @@ import java.io.Closeable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -81,7 +82,7 @@ public class ChromeDevToolsClient implements Closeable {
     try {
       return new ChromeDevToolsSession(
         new URI(uri),
-        targetId,
+        Optional.of(targetId),
         objectMapper,
         executorService,
         actionTimeoutMillis

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsClient.java
@@ -77,12 +77,9 @@ public class ChromeDevToolsClient implements Closeable {
     return connectToTarget(host, port, targetId);
   }
 
-  public ChromeDevToolsSession connect(String host, int port, TargetID targetId) {
-    try {
-      return connectToTarget(host, port, targetId);
-    } catch (URISyntaxException e) {
-      throw new ChromeDevToolsException(e);
-    }
+  public ChromeDevToolsSession connect(String host, int port, TargetID targetId)
+    throws URISyntaxException {
+    return connectToTarget(host, port, targetId);
   }
 
   private ChromeDevToolsSession connectToTarget(String host, int port, TargetID targetId)

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
@@ -96,6 +96,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   private final ObjectMapper objectMapper;
   private final ExecutorService executorService;
   private final UUID id;
+  private final String targetId;
 
   private final Map<String, ChromeEventListener> chromeEventListeners;
 
@@ -117,6 +118,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     this.objectMapper = objectMapper;
     this.executorService = executorService;
     this.id = UUID.randomUUID();
+    this.targetId = uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
 
     try {
       this.websocket.connectBlocking();
@@ -139,6 +141,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     this.objectMapper = objectMapper;
     this.executorService = executorService;
     this.id = UUID.randomUUID();
+    this.targetId = null;
   }
 
   @Override
@@ -236,6 +239,10 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
 
   public boolean isConnected() {
     return websocket.isOpen();
+  }
+
+  public String getTargetId() {
+    return targetId;
   }
 
   public void waitDocumentReady() {

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
@@ -120,12 +120,26 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     this.id = UUID.randomUUID();
     this.targetId = uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
 
+    boolean connected;
     try {
-      this.websocket.connectBlocking();
+      connected =
+        this.websocket.connectBlocking(actionTimeoutMillis, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ChromeDevToolsException(
+        String.format("Interrupted while connecting to uri %s", uri),
+        e
+      );
     } catch (Throwable t) {
       throw new ChromeDevToolsException(
         String.format("Could not connect to uri %s", uri),
         t
+      );
+    }
+
+    if (!connected) {
+      throw new ChromeDevToolsException(
+        String.format("Could not connect to uri %s; the target may no longer exist", uri)
       );
     }
   }

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
@@ -61,6 +61,7 @@ import com.hubspot.chrome.devtools.client.core.storage.Storage;
 import com.hubspot.chrome.devtools.client.core.systeminfo.SystemInfo;
 import com.hubspot.chrome.devtools.client.core.target.SessionID;
 import com.hubspot.chrome.devtools.client.core.target.Target;
+import com.hubspot.chrome.devtools.client.core.target.TargetID;
 import com.hubspot.chrome.devtools.client.core.tethering.Tethering;
 import com.hubspot.chrome.devtools.client.core.tracing.Tracing;
 import com.hubspot.chrome.devtools.client.exceptions.ChromeDevToolsException;
@@ -73,6 +74,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -96,12 +98,22 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   private final ObjectMapper objectMapper;
   private final ExecutorService executorService;
   private final UUID id;
-  private final String targetId;
+  private final TargetID targetId;
 
   private final Map<String, ChromeEventListener> chromeEventListeners;
 
   public ChromeDevToolsSession(
     URI uri,
+    ObjectMapper objectMapper,
+    ExecutorService executorService,
+    long actionTimeoutMillis
+  ) {
+    this(uri, null, objectMapper, executorService, actionTimeoutMillis);
+  }
+
+  public ChromeDevToolsSession(
+    URI uri,
+    TargetID targetId,
     ObjectMapper objectMapper,
     ExecutorService executorService,
     long actionTimeoutMillis
@@ -118,7 +130,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     this.objectMapper = objectMapper;
     this.executorService = executorService;
     this.id = UUID.randomUUID();
-    this.targetId = uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
+    this.targetId = targetId;
 
     boolean connected;
     try {
@@ -255,8 +267,8 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     return websocket.isOpen();
   }
 
-  public String getTargetId() {
-    return targetId;
+  public Optional<TargetID> getTargetId() {
+    return Optional.ofNullable(targetId);
   }
 
   public void waitDocumentReady() {

--- a/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
+++ b/ChromeDevToolsClient/src/main/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSession.java
@@ -98,7 +98,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   private final ObjectMapper objectMapper;
   private final ExecutorService executorService;
   private final UUID id;
-  private final TargetID targetId;
+  private final Optional<TargetID> targetId;
 
   private final Map<String, ChromeEventListener> chromeEventListeners;
 
@@ -108,12 +108,12 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     ExecutorService executorService,
     long actionTimeoutMillis
   ) {
-    this(uri, null, objectMapper, executorService, actionTimeoutMillis);
+    this(uri, Optional.empty(), objectMapper, executorService, actionTimeoutMillis);
   }
 
   public ChromeDevToolsSession(
     URI uri,
-    TargetID targetId,
+    Optional<TargetID> targetId,
     ObjectMapper objectMapper,
     ExecutorService executorService,
     long actionTimeoutMillis
@@ -167,7 +167,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
     this.objectMapper = objectMapper;
     this.executorService = executorService;
     this.id = UUID.randomUUID();
-    this.targetId = null;
+    this.targetId = Optional.empty();
   }
 
   @Override
@@ -268,7 +268,7 @@ public class ChromeDevToolsSession implements ChromeSessionCore {
   }
 
   public Optional<TargetID> getTargetId() {
-    return Optional.ofNullable(targetId);
+    return targetId;
   }
 
   public void waitDocumentReady() {

--- a/ChromeDevToolsClient/src/test/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSessionTest.java
+++ b/ChromeDevToolsClient/src/test/java/com/hubspot/chrome/devtools/client/ChromeDevToolsSessionTest.java
@@ -1,0 +1,34 @@
+package com.hubspot.chrome.devtools.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.chrome.devtools.client.exceptions.ChromeDevToolsException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
+import org.junit.Test;
+
+public class ChromeDevToolsSessionTest {
+
+  @Test
+  public void itFailsFastWhenTheTargetCannotBeConnectedTo() throws Exception {
+    ObjectMapper objectMapper = ChromeDevToolsClientDefaults.DEFAULT_OBJECT_MAPPER;
+    ExecutorService executorService =
+      ChromeDevToolsClientDefaults.DEFAULT_EXECUTOR_SERVICE;
+
+    int unusedPort;
+    try (ServerSocket socket = new ServerSocket(0)) {
+      unusedPort = socket.getLocalPort();
+    }
+
+    URI uri = URI.create(
+      String.format("ws://localhost:%d/devtools/page/dead-target", unusedPort)
+    );
+
+    assertThatThrownBy(() ->
+        new ChromeDevToolsSession(uri, objectMapper, executorService, 1000L)
+      )
+      .isInstanceOf(ChromeDevToolsException.class);
+  }
+}


### PR DESCRIPTION
https://github.com/HubSpotEngineering/fintech-sox-tooling-issues/issues/130

Supersedes #98 (opened from a fork I can't push to). This branch contains the original change plus a fix for the review feedback on that PR.

## Summary
- Adds a `connect(host, port, targetId)` overload to `ChromeDevToolsClient` to reconnect to an existing session without re-discovering the target.
- Adds `getTargetId()` to `ChromeDevToolsSession` to expose the target ID for stateless reconnection.

## Why
Enables stateless browser session reconnection where the caller already knows the target ID (e.g. stored from a previous session) and reconnects directly without re-fetching the target list.

## Addressing review feedback (dead-session reconnect)
The reconnect path relies on the shared `ChromeDevToolsSession` constructor, which called `connectBlocking()` and ignored its boolean return. When a target has died on the agent side, Chrome rejects the handshake and `connectBlocking()` returns `false` — so the old code threw nothing and returned a session that looked constructed but was actually disconnected. That silently-broken session is what would let a caller's connect retryer spin against a session that will never come back.

Now the constructor bounds the connect with the action timeout and throws a clear `ChromeDevToolsException` when the socket never opened, so a dead-session reconnect fails fast and unambiguously. Retry policy stays with the caller (`CHROME_CONNECT_RETRYER`); this just gives it a clean signal to give up on. Deliberately avoids a `/json/list` validation, which would re-add the target-list round-trip the stateless design exists to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)